### PR TITLE
Ajustes de acesibilidade

### DIFF
--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -29,8 +29,8 @@ const Container = styled.a`
   }
 `
 
-const Icon = ({ icon, url }) => (
-  <Container href={url} target="_blank">
+const Icon = ({ icon, url, title }) => (
+  <Container href={url} target="_blank" title={title}>
     <FontAwesomeIcon className="icon" icon={icon} />
   </Container>
 )

--- a/src/sections/Header.js
+++ b/src/sections/Header.js
@@ -118,9 +118,9 @@ export default function Header({ title }) {
       </Content>
 
       <Footer>
-        <Icon icon={faTwitter} url="https://twitter.com/frontinmga" />
-        <Icon icon={faFacebookF} url="https://facebook.com/frontinmga" />
-        <Icon icon={faGithubAlt} url="https://github.com/frontinmga" />
+        <Icon icon={faTwitter} url="https://twitter.com/frontinmga" title="Siga-nos no twitter" />
+        <Icon icon={faFacebookF} url="https://facebook.com/frontinmga" title="Nos acompanhe no facebook" />
+        <Icon icon={faGithubAlt} url="https://github.com/frontinmga" title="Confira nosso github" />
       </Footer>
     </Container>
   )

--- a/src/sections/Schedule.js
+++ b/src/sections/Schedule.js
@@ -125,7 +125,7 @@ const Slot = ({
     <Hour>{hour}</Hour>
     <Circle line={line} />
     <Speaker>
-      {image && <img className="photo" src={image} />}
+      {image && <img className="photo" src={image} alt={name} />}
       <Description>
         <h3>{name}</h3>
         <p>{description}</p>


### PR DESCRIPTION
Rodando o Lighthouse no site percebi que tinham alguns pequenos detalhes relacionados a acessibilidade que estavam deixando a nota um tanto quanto baixa, conforme imagem abaixo
![Captura de Tela 2019-08-13 às 19 28 26](https://user-images.githubusercontent.com/16037749/62981872-d6879d00-be00-11e9-807d-44abda2f2caf.png)

Coloquei um título nos links das redes sociais e o atributo alt para as imagens dos palestrantes e a pontuação já subiu consideravelmente, conforme imagem abaixo
![Captura de Tela 2019-08-13 às 19 29 22](https://user-images.githubusercontent.com/16037749/62981940-0df64980-be01-11e9-968e-825c99bcc023.png)

Para dar 100% faltaram dois pontos:
- Inserir um `title` na página
- Declarar o `lang` da página

Eu não consegui arrumar esses dois pontos... Testei diversas coisas mas, como ainda não vi muito sobre Gatsby e etc, não deu resultado rs